### PR TITLE
have sorting algorithm prioritize correctly

### DIFF
--- a/src/lib/routeListSort.js
+++ b/src/lib/routeListSort.js
@@ -2,8 +2,9 @@
 
 
 function routeListSort(file) {
-    if (file.match(/\:/)) {
-        return 1;
+    var matches = file.match(/\:/g);
+    if (matches) {
+        return matches.length;
     }
     else {
         return 0;


### PR DESCRIPTION
When dealing with a route with two parameters, there was no logic that ensured it would be registered after a route with one parameter.

@jreynolds-daptiv @park9140 